### PR TITLE
Allow symfony/console 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "teamleadercrm/uuidifier",
     "require": {
         "ramsey/uuid": "^3.7",
-        "symfony/console": "^3.1"
+        "symfony/console": "^3.1|^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Ran `composer update` and console was updated to `4.0` and everything still worked!