### PR TITLE
Fix encode/decode commands

### DIFF
--- a/src/Command/Decode.php
+++ b/src/Command/Decode.php
@@ -28,5 +28,7 @@ class Decode extends Command
         $uuid = $input->getArgument('uuid');
         $int = $uuidifier->decode(Uuid::fromString($uuid));
         $output->writeln($int);
+
+        return self::SUCCESS;
     }
 }

--- a/src/Command/Decode.php
+++ b/src/Command/Decode.php
@@ -11,6 +11,8 @@ use Teamleader\Uuidifier\Uuidifier;
 
 class Decode extends Command
 {
+    const SUCCESS = 0;
+
     protected function configure()
     {
         $this->setName('uuidifier:decode');

--- a/src/Command/Encode.php
+++ b/src/Command/Encode.php
@@ -10,6 +10,8 @@ use Teamleader\Uuidifier\Uuidifier;
 
 class Encode extends Command
 {
+    const SUCCESS = 0;
+
     protected function configure()
     {
         $this->setName('uuidifier:encode');

--- a/src/Command/Encode.php
+++ b/src/Command/Encode.php
@@ -36,5 +36,7 @@ class Encode extends Command
             $id
         );
         $output->writeln((string) $uuid);
+
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
The return type on the base Command class has been added upstream, so we must return an int now.

```
PHP Fatal error:  Uncaught TypeError: Return value of "Teamleader\Uuidifier\Command\Encode::execute()" must be of the type int, "null" returned. in /var/www/composer/symfony/console/Command/Command.php:261
```