### PR TITLE
Allow `symfony/console:^6.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.1"
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "teamleadercrm/uuidifier",
     "require": {
         "ramsey/uuid": "^3.9",
-        "symfony/console": "^3.1|^4.0|^5.0"
+        "symfony/console": "^3.1|^4.0|^5.0|^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Let's allow `symfony/console:^6.0` to be used so we can start bumping our services.