### PR TITLE
Add test that verifies if uuids remain the same in prep for ramsey v4

### DIFF
--- a/tests/UudifierTest.php
+++ b/tests/UudifierTest.php
@@ -85,4 +85,29 @@ class UudifierTest extends TestCase
         $this->assertTrue($generator->isValid('foo', $uuid1));
         $this->assertFalse($generator->isValid('foo', $uuid2));
     }
+
+    private function providesPreviouslyGeneratedUuids(): array
+    {
+        return [
+            ['foo', 1, '18a16d45-3076-0ef4-b311-d306c9f6c591'],
+            ['foo', 2, 'aaadd949-77b8-0bf3-b61b-09fc3bbbc9e2'],
+            ['foo', 3, 'fa129605-92c4-00f7-811c-2d4a31ee6523'],
+            ['bar', 3, '89c76b7f-d66c-04b1-a511-c31d2482ef23'],
+            ['bar', 4, 'c542f2cd-cfd5-0279-941b-2be43ee31c64'],
+            ['foo', 42, 'af616ff7-e491-06bc-b62e-b9a8ca12fd2a'],
+            ['foo', 999999999, '28bb05fc-9542-0c26-a384-86ae3b9ac9ff'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider providesPreviouslyGeneratedUuids
+     */
+    public function uuidIsPermanentlyTheSame(string $prefix, int $id, string $expectedUuid)
+    {
+        $generator = new Uuidifier();
+        $uuid = $generator->encode($prefix, $id);
+
+        $this->assertEquals($expectedUuid, $uuid->toString());
+    }
 }


### PR DESCRIPTION
This test should still succeed after upgrading to ramsay/uuid v4