### PR TITLE
Upgrade/ramsey UUID v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "teamleadercrm/uuidifier",
     "require": {
-        "ramsey/uuid": "^3.9",
+        "ramsey/uuid": "^4.2",
         "symfony/console": "^3.1|^4.0|^5.0|^6.0"
     },
     "autoload": {

--- a/src/Builder/VersionZeroUuidBuilder.php
+++ b/src/Builder/VersionZeroUuidBuilder.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Teamleader\Uuidifier\Builder;
+
+use Ramsey\Uuid\Builder\UuidBuilderInterface;
+use Ramsey\Uuid\Codec\CodecInterface;
+use Ramsey\Uuid\Converter\NumberConverterInterface;
+use Ramsey\Uuid\Converter\TimeConverterInterface;
+use Ramsey\Uuid\Exception\UnableToBuildUuidException;
+use Ramsey\Uuid\UuidInterface;
+use Teamleader\Uuidifier\Nonstandard\UuidV0;
+use Teamleader\Uuidifier\Nonstandard\VersionZeroFields;
+use Throwable;
+
+final class VersionZeroUuidBuilder implements UuidBuilderInterface
+{
+    public function __construct(
+        private NumberConverterInterface $numberConverter,
+        private TimeConverterInterface $timeConverter,
+    ) {
+    }
+
+    public function build(CodecInterface $codec, string $bytes): UuidInterface
+    {
+        try {
+            return new UuidV0(
+                $this->buildFields($bytes),
+                $this->numberConverter,
+                $codec,
+                $this->timeConverter,
+            );
+        } catch (Throwable $e) {
+            throw new UnableToBuildUuidException($e->getMessage(), (int) $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * Proxy method to allow injecting a mock, for testing
+     */
+    protected function buildFields(string $bytes): VersionZeroFields
+    {
+        return new VersionZeroFields($bytes);
+    }
+}

--- a/src/Nonstandard/UuidV0.php
+++ b/src/Nonstandard/UuidV0.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Teamleader\Uuidifier\Nonstandard;
+
+use Ramsey\Uuid\Codec\CodecInterface;
+use Ramsey\Uuid\Converter\NumberConverterInterface;
+use Ramsey\Uuid\Converter\TimeConverterInterface;
+use Ramsey\Uuid\Exception\InvalidArgumentException;
+use Ramsey\Uuid\Rfc4122\FieldsInterface as Rfc4122FieldsInterface;
+use Ramsey\Uuid\Uuid;
+
+final class UuidV0 extends Uuid
+{
+    public function __construct(
+        Rfc4122FieldsInterface $fields,
+        NumberConverterInterface $numberConverter,
+        CodecInterface $codec,
+        TimeConverterInterface $timeConverter
+    ) {
+        if ($fields->getVersion() !== 0) {
+            throw new InvalidArgumentException(
+                'Fields used to create a UuidV0 must represent a version 0 (incremental) UUID',
+            );
+        }
+
+        parent::__construct($fields, $numberConverter, $codec, $timeConverter);
+    }
+}

--- a/src/Nonstandard/VersionZeroFields.php
+++ b/src/Nonstandard/VersionZeroFields.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Teamleader\Uuidifier\Nonstandard;
+
+use Ramsey\Uuid\Exception\InvalidArgumentException;
+use Ramsey\Uuid\Fields\SerializableFieldsTrait;
+use Ramsey\Uuid\Rfc4122\FieldsInterface;
+use Ramsey\Uuid\Rfc4122\NilTrait;
+use Ramsey\Uuid\Rfc4122\VariantTrait;
+use Ramsey\Uuid\Type\Hexadecimal;
+use Ramsey\Uuid\Uuid;
+
+final class VersionZeroFields implements FieldsInterface
+{
+    use NilTrait;
+    use SerializableFieldsTrait;
+    use VariantTrait;
+
+    /**
+     * @param string $bytes A 16-byte binary string representation of a UUID
+     *
+     * @throws InvalidArgumentException if the byte string is not exactly 16 bytes
+     */
+    public function __construct(
+        private string $bytes,
+    ) {
+        if (strlen($bytes) !== 16) {
+            throw new InvalidArgumentException(
+                'The byte string must be 16 bytes long; '
+                . 'received ' . strlen($bytes) . ' bytes'
+            );
+        }
+
+        if (!$this->isCorrectVariant()) {
+            throw new InvalidArgumentException(
+                'The byte string received does not conform to the RFC 4122 variant'
+            );
+        }
+    }
+
+    public function getBytes(): string
+    {
+        return $this->bytes;
+    }
+
+    public function getClockSeq(): Hexadecimal
+    {
+        $clockSeq = hexdec(bin2hex(substr($this->bytes, 8, 2))) & 0x3fff;
+
+        return new Hexadecimal(str_pad(dechex($clockSeq), 4, '0', STR_PAD_LEFT));
+    }
+
+    public function getClockSeqHiAndReserved(): Hexadecimal
+    {
+        return new Hexadecimal(bin2hex(substr($this->bytes, 8, 1)));
+    }
+
+    public function getClockSeqLow(): Hexadecimal
+    {
+        return new Hexadecimal(bin2hex(substr($this->bytes, 9, 1)));
+    }
+
+    public function getNode(): Hexadecimal
+    {
+        return new Hexadecimal(bin2hex(substr($this->bytes, 10)));
+    }
+
+    public function getTimeHiAndVersion(): Hexadecimal
+    {
+        return new Hexadecimal(bin2hex(substr($this->bytes, 6, 2)));
+    }
+
+    public function getTimeLow(): Hexadecimal
+    {
+        return new Hexadecimal(bin2hex(substr($this->bytes, 0, 4)));
+    }
+
+    public function getTimeMid(): Hexadecimal
+    {
+        return new Hexadecimal(bin2hex(substr($this->bytes, 4, 2)));
+    }
+
+    public function getTimestamp(): Hexadecimal
+    {
+        return new Hexadecimal(
+            sprintf(
+                '%03x%04s%08s',
+                hexdec($this->getTimeHiAndVersion()->toString()) & 0x0fff,
+                $this->getTimeMid()->toString(),
+                $this->getTimeLow()->toString(),
+            ),
+        );
+    }
+
+    public function getVersion(): ?int
+    {
+        if ($this->isNil()) {
+            return null;
+        }
+
+        $parts = unpack('n*', $this->bytes);
+
+        return (int) $parts[4] >> 12;
+    }
+
+
+    private function isCorrectVariant(): bool
+    {
+        if ($this->isNil()) {
+            return true;
+        }
+
+        return $this->getVariant() === Uuid::RFC_4122;
+    }
+}

--- a/src/Uuidifier.php
+++ b/src/Uuidifier.php
@@ -46,7 +46,7 @@ class Uuidifier
 
     public function decode(UuidInterface $uuid): int
     {
-        if ($uuid->getVersion() != $this->version) {
+        if ($uuid->getVersion() !== $this->version) {
             throw new InvalidArgumentException('Can only decode version ' . $this->version . ' uuids');
         }
 
@@ -58,6 +58,10 @@ class Uuidifier
 
     public function isValid(string $prefix, UuidInterface $uuid): bool
     {
+        if ($uuid->getVersion() !== $this->version) {
+            return false;
+        }
+
         $decoded = $this->decode($uuid);
         $encoded = $this->encode($prefix, $decoded);
 

--- a/src/Uuidifier.php
+++ b/src/Uuidifier.php
@@ -9,18 +9,7 @@ use Ramsey\Uuid\UuidInterface;
 
 class Uuidifier
 {
-    /**
-     * @var int
-     */
-    private $version;
-
-    /**
-     * @param int $version
-     */
-    public function __construct($version = 0)
-    {
-        $this->version = $version;
-    }
+    private const VERSION = 0;
 
     public function encode(string $prefix, int $id): UuidInterface
     {
@@ -29,7 +18,7 @@ class Uuidifier
         $length = strlen($hex);
         $hash = substr($hash, 0, 32 - $length) . $hex;
 
-        $timeHi = BinaryUtils::applyVersion(substr($hash, 12, 4), $this->version);
+        $timeHi = BinaryUtils::applyVersion(substr($hash, 12, 4), self::VERSION);
         $clockSeqHi = BinaryUtils::applyVariant(hexdec(substr($hash, 16, 2)));
 
         $fields = [
@@ -46,8 +35,8 @@ class Uuidifier
 
     public function decode(UuidInterface $uuid): int
     {
-        if ($uuid->getVersion() !== $this->version) {
-            throw new InvalidArgumentException('Can only decode version ' . $this->version . ' uuids');
+        if ($uuid->getVersion() !== self::VERSION) {
+            throw new InvalidArgumentException('Can only decode version ' . self::VERSION . ' uuids');
         }
 
         $length = hexdec($uuid->getClockSeqLowHex()[0]);
@@ -58,7 +47,7 @@ class Uuidifier
 
     public function isValid(string $prefix, UuidInterface $uuid): bool
     {
-        if ($uuid->getVersion() !== $this->version) {
+        if ($uuid->getVersion() !== self::VERSION) {
             return false;
         }
 

--- a/src/Uuidifier.php
+++ b/src/Uuidifier.php
@@ -22,17 +22,8 @@ class Uuidifier
         $this->version = $version;
     }
 
-    /**
-     * @param string $prefix
-     * @param int $id
-     * @return UuidInterface
-     */
-    public function encode($prefix, $id)
+    public function encode(string $prefix, int $id): UuidInterface
     {
-        if (!is_int($id)) {
-            throw new InvalidArgumentException('Can only encode integers');
-        }
-
         $hash = sha1($prefix . $id);
         $hex = dechex($id);
         $length = strlen($hex);
@@ -53,11 +44,7 @@ class Uuidifier
         return (new UuidFactory())->uuid($fields);
     }
 
-    /**
-     * @param UuidInterface $uuid
-     * @return int
-     */
-    public function decode(UuidInterface $uuid)
+    public function decode(UuidInterface $uuid): int
     {
         if ($uuid->getVersion() != $this->version) {
             throw new InvalidArgumentException('Can only decode version ' . $this->version . ' uuids');
@@ -69,13 +56,7 @@ class Uuidifier
         return hexdec($hex);
     }
 
-    /**
-     * @param string $prefix
-     * @param UuidInterface $uuid
-     *
-     * @return bool
-     */
-    public function isValid($prefix, UuidInterface $uuid)
+    public function isValid(string $prefix, UuidInterface $uuid): bool
     {
         $decoded = $this->decode($uuid);
         $encoded = $this->encode($prefix, $decoded);

--- a/tests/UudifierTest.php
+++ b/tests/UudifierTest.php
@@ -36,9 +36,9 @@ class UudifierTest extends TestCase
      */
     public function itEmbedsTheVersion()
     {
-        $generator = new Uuidifier(9);
+        $generator = new Uuidifier();
         $uuid = $generator->encode('foo', 1);
-        $this->assertEquals(9, $uuid->getVersion());
+        $this->assertEquals(0, $uuid->getVersion());
     }
 
     /**

--- a/tests/UuidifierTest.php
+++ b/tests/UuidifierTest.php
@@ -5,7 +5,7 @@ use Ramsey\Uuid\UuidInterface;
 use Teamleader\Uuidifier\Uuidifier;
 use Ramsey\Uuid\Uuid;
 
-class UudifierTest extends TestCase
+class UuidifierTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
Solve the blocking issue with ramsey/uuid v4+ caused by the fact that creating a Uuid with version 0 now returns a non-standard Uuid object on which `getVersion()` will return `null`.

In order to fix this we create our own UuidV0 object and accompanying VersionZeroUuidBuilder (https://github.com/ramsey/uuid/issues/404).

Also I ported the old `BinaryUtils` methods `applyVersion` and `applyVariant` from v3 to our own codebase, because both `BinaryUtils` methods have a changed signature, and the new ones expect a different number of bytes, creating a hazard for the consistency in our encode/decode mechanism (https://teamleader.atlassian.net/wiki/spaces/ENG/pages/3617488920/Updating+composer+libraries).

**Not ready to merge yet. Still need to add tests for the new classes.**