### PR TITLE
Allow standard UUIDs as well to be decoded

### DIFF
--- a/src/Uuidifier.php
+++ b/src/Uuidifier.php
@@ -10,6 +10,7 @@ use Ramsey\Uuid\Math\BrickMathCalculator;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\UuidInterface;
 use Teamleader\Uuidifier\Builder\VersionZeroUuidBuilder;
+use Teamleader\Uuidifier\Nonstandard\UuidV0;
 
 class Uuidifier
 {
@@ -55,7 +56,7 @@ class Uuidifier
     public function decode(UuidInterface $uuid): int
     {
         if ($uuid->getVersion() !== self::VERSION) {
-            throw new InvalidArgumentException('Can only decode version ' . self::VERSION . ' uuids');
+            $uuid = $this->transformUnknownUuidIntoUuidVersionZero($uuid);
         }
 
         $length = hexdec($uuid->getClockSeqLowHex()[0]);
@@ -67,13 +68,18 @@ class Uuidifier
     public function isValid(string $prefix, UuidInterface $uuid): bool
     {
         if ($uuid->getVersion() !== self::VERSION) {
-            return false;
+            $uuid = $this->transformUnknownUuidIntoUuidVersionZero($uuid);
         }
 
         $decoded = $this->decode($uuid);
         $encoded = $this->encode($prefix, $decoded);
 
         return $uuid->equals($encoded);
+    }
+
+    private function transformUnknownUuidIntoUuidVersionZero(UuidInterface $uuid): UuidInterface
+    {
+        return UuidV0::fromString($uuid->toString());
     }
 
     /**

--- a/tests/UuidifierTest.php
+++ b/tests/UuidifierTest.php
@@ -132,9 +132,33 @@ class UuidifierTest extends TestCase
     public function decodedIdIsPermanentlyTheSame(string $uuid, int $expectedId)
     {
         $generator = new Uuidifier();
-        $uuid = UuidV0::fromString($uuid);
+        $uuid = Uuid::fromString($uuid);
         $id = $generator->decode($uuid);
 
         $this->assertEquals($expectedId, $id);
+    }
+
+    /**
+     * @test
+     */
+    public function testDecodingANonStandardUuidV0Works()
+    {
+        $generator = new Uuidifier();
+        $uuid = UuidV0::fromString('af616ff7-e491-06bc-b62e-b9a8ca12fd2a');
+        $id = $generator->decode($uuid);
+
+        $this->assertEquals(42, $id);
+    }
+
+    /**
+     * @test
+     */
+    public function testDecodingAStandardUuidWorks()
+    {
+        $generator = new Uuidifier();
+        $uuid = Uuid::fromString('af616ff7-e491-06bc-b62e-b9a8ca12fd2a');
+        $id = $generator->decode($uuid);
+
+        $this->assertEquals(42, $id);
     }
 }


### PR DESCRIPTION
By providing automatic fallback to UuidV0