### PR TITLE
Only support ramsey up to v4.4.0, as v4.5.0 requires changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "teamleadercrm/uuidifier",
     "require": {
-        "ramsey/uuid": "^4.2",
+        "ramsey/uuid": ">=4.2 <4.5",
         "symfony/console": "^3.1|^4.0|^5.0|^6.0"
     },
     "autoload": {


### PR DESCRIPTION
Ramsey/uuid v4.5.0 makes changes in this trait: https://github.com/ramsey/uuid/blob/4.5.0/src/Rfc4122/VariantTrait.php

We don't have these changes in uuidifier v1.7.0 so we only support ramsey/uuid up to v4.4.0 maximum. Therefore make the version constraints more strict.

Q: This should have been included in uuidifier version v1.7 -> can we re-create the v1.7.0 tag? Then we don't need to have the fix in a 1.7.1 patch release, otherwise dependent projects will still go try to grab v1.7.0.