### PR TITLE
Support Ramsey UUID 4.5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "teamleadercrm/uuidifier",
     "require": {
-        "ramsey/uuid": ">=4.2 <4.5",
+        "ramsey/uuid": ">=4.2 <4.6",
         "symfony/console": "^3.1|^4.0|^5.0|^6.0"
     },
     "autoload": {

--- a/src/Nonstandard/VersionZeroFields.php
+++ b/src/Nonstandard/VersionZeroFields.php
@@ -118,7 +118,6 @@ final class VersionZeroFields implements FieldsInterface
         return (int) $parts[4] >> 12;
     }
 
-
     private function isCorrectVariant(): bool
     {
         if ($this->isMax() || $this->isNil()) {

--- a/src/Nonstandard/VersionZeroFields.php
+++ b/src/Nonstandard/VersionZeroFields.php
@@ -7,6 +7,7 @@ namespace Teamleader\Uuidifier\Nonstandard;
 use Ramsey\Uuid\Exception\InvalidArgumentException;
 use Ramsey\Uuid\Fields\SerializableFieldsTrait;
 use Ramsey\Uuid\Rfc4122\FieldsInterface;
+use Ramsey\Uuid\Rfc4122\MaxTrait;
 use Ramsey\Uuid\Rfc4122\NilTrait;
 use Ramsey\Uuid\Rfc4122\VariantTrait;
 use Ramsey\Uuid\Type\Hexadecimal;
@@ -14,6 +15,7 @@ use Ramsey\Uuid\Uuid;
 
 final class VersionZeroFields implements FieldsInterface
 {
+    use MaxTrait;
     use NilTrait;
     use SerializableFieldsTrait;
     use VariantTrait;
@@ -105,7 +107,7 @@ final class VersionZeroFields implements FieldsInterface
 
     public function getVersion(): ?int
     {
-        if ($this->isNil()) {
+        if ($this->isMax() || $this->isNil()) {
             return null;
         }
 
@@ -117,7 +119,7 @@ final class VersionZeroFields implements FieldsInterface
 
     private function isCorrectVariant(): bool
     {
-        if ($this->isNil()) {
+        if ($this->isMax() || $this->isNil()) {
             return true;
         }
 
@@ -126,7 +128,7 @@ final class VersionZeroFields implements FieldsInterface
 
     private function isCorrectVersion(): bool
     {
-        if ($this->isNil()) {
+        if ($this->isMax() || $this->isNil()) {
             return true;
         }
 

--- a/src/Nonstandard/VersionZeroFields.php
+++ b/src/Nonstandard/VersionZeroFields.php
@@ -10,6 +10,7 @@ use Ramsey\Uuid\Rfc4122\FieldsInterface;
 use Ramsey\Uuid\Rfc4122\MaxTrait;
 use Ramsey\Uuid\Rfc4122\NilTrait;
 use Ramsey\Uuid\Rfc4122\VariantTrait;
+use Ramsey\Uuid\Rfc4122\VersionTrait;
 use Ramsey\Uuid\Type\Hexadecimal;
 use Ramsey\Uuid\Uuid;
 
@@ -19,6 +20,7 @@ final class VersionZeroFields implements FieldsInterface
     use NilTrait;
     use SerializableFieldsTrait;
     use VariantTrait;
+    use VersionTrait;
 
     private string $bytes;
 


### PR DESCRIPTION
Support ramsey 4.5.x by adding support for isMax (https://github.com/ramsey/uuid/releases/tag/4.5.0)