### PR TITLE
Update `symfony/console` constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "require": {
         "php": "^8.1",
         "ramsey/uuid": ">=4.5 <4.6",
-        "symfony/console": "^3.1|^4.0|^5.0|^6.0"
+        "symfony/console": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "teamleadercrm/uuidifier",
+    "version": "1.9.0",
     "require": {
         "php": "^8.1",
         "ramsey/uuid": ">=4.5 <4.6",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "teamleadercrm/uuidifier",
     "require": {
+        "php": "^8.1",
         "ramsey/uuid": ">=4.5 <4.6",
         "symfony/console": "^3.1|^4.0|^5.0|^6.0"
     },


### PR DESCRIPTION
We must be able to update to `symfony/console:^7.0` 