### PR TITLE
Handle uuid exceptions gracefully during uuid validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "teamleadercrm/uuidifier",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "require": {
         "php": "^8.1",
         "ramsey/uuid": ">=4.5 <4.6",

--- a/src/Uuidifier.php
+++ b/src/Uuidifier.php
@@ -53,6 +53,9 @@ class Uuidifier
         return $uuidFactory->uuid($bytes);
     }
 
+    /**
+     * @throws UuidExceptionInterface
+     */
     public function decode(UuidInterface $uuid): int
     {
         if ($uuid->getVersion() !== self::VERSION) {

--- a/src/Uuidifier.php
+++ b/src/Uuidifier.php
@@ -2,10 +2,10 @@
 
 namespace Teamleader\Uuidifier;
 
-use InvalidArgumentException;
 use Ramsey\Uuid\Codec\StringCodec;
 use Ramsey\Uuid\Converter\Number\GenericNumberConverter;
 use Ramsey\Uuid\Converter\Time\GenericTimeConverter;
+use Ramsey\Uuid\Exception\UuidExceptionInterface;
 use Ramsey\Uuid\Math\BrickMathCalculator;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\UuidInterface;
@@ -77,6 +77,9 @@ class Uuidifier
         return $uuid->equals($encoded);
     }
 
+    /**
+     * @throws UuidExceptionInterface
+     */
     private function transformUnknownUuidIntoUuidVersionZero(UuidInterface $uuid): UuidInterface
     {
         return UuidV0::fromString($uuid->toString());

--- a/src/Uuidifier.php
+++ b/src/Uuidifier.php
@@ -68,7 +68,11 @@ class Uuidifier
     public function isValid(string $prefix, UuidInterface $uuid): bool
     {
         if ($uuid->getVersion() !== self::VERSION) {
-            $uuid = $this->transformUnknownUuidIntoUuidVersionZero($uuid);
+            try {
+                $uuid = $this->transformUnknownUuidIntoUuidVersionZero($uuid);
+            } catch (UuidExceptionInterface) {
+                return false;
+            }
         }
 
         $decoded = $this->decode($uuid);

--- a/tests/UuidifierTest.php
+++ b/tests/UuidifierTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 use Teamleader\Uuidifier\Nonstandard\UuidV0;
@@ -71,6 +72,18 @@ class UuidifierTest extends TestCase
         $generator = new Uuidifier();
         $uuid = $generator->encode('foo', 1);
         $this->assertFalse($generator->isValid('bar', $uuid));
+    }
+
+    /**
+     * @test
+     */
+    public function uuidWithInvalidVersionIsInvalid(): void
+    {
+        $generator = new Uuidifier();
+
+        $uuid = Uuid::fromString('018dc552-ce8c-77ad-8c27-289ac479d815'); // V7 UUID
+
+        Assert::assertFalse($generator->isValid('foo', $uuid));
     }
 
     /**


### PR DESCRIPTION
Certain Uuids can't be converted to UuidV0 values.
In that case an exception is thrown.

When we are performing Uuid validation, we always expect a true/false return type, and no exception.

That is why I propose to handle these exceptions gracefully. 