### PR TITLE
Expand the ramsey/uuid version constraints so that the current latest version (4.7.6) is supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "teamleadercrm/uuidifier",
-    "version": "1.9.1",
+    "version": "1.10.0",
     "require": {
         "php": "^8.1",
         "ramsey/uuid": ">=4.5 <4.8",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "version": "1.9.1",
     "require": {
         "php": "^8.1",
-        "ramsey/uuid": ">=4.5 <4.6",
+        "ramsey/uuid": ">=4.5 <4.8",
         "symfony/console": "^6.0|^7.0"
     },
     "autoload": {


### PR DESCRIPTION
### Link

https://github.com/ramsey/uuid/releases

### Description

- Expand the version constraints so that the current latest version (4.7.6) is supported
	- The new releases bring some valuable fixes for UUIDv7 against collisions
- Perform minor version bump
